### PR TITLE
Add type:module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "remark parser plugin for custom directive in markdown",
   "author": "koka831",
   "license": "MIT",
+  "type": "module",
   "export": "dist/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Using this in astro breaks with error. Astro relies on Vite, so high probability that this is breaking on more projects using plain Vite.

Adding type: module fixes the error. Shouldn't affect anything else, as it is ESM only