### PR TITLE
support multi-line contents inside the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # remark-custom-container
 
 [remarkjs][remarkjs] parser plugin for custom directive (compatible with new parser in remark. see [#536][536])
-NOTE: This plugin is highly inspired by [vuepress-plugin-container][vuepress-plugin-container].
+
+> **Note**
+> This plugin is highly inspired by [vuepress-plugin-container][vuepress-plugin-container].
 
 This package is ESM only: Node 12+ is needed to use it and it must be `import`ed instead of `require`d.
 
@@ -13,7 +15,9 @@ example:
 
 ```markdown
 ::: className Custom Title
+
 Container Body
+
 :::
 ```
 
@@ -57,10 +61,6 @@ use(container, {
   containerTag: string // default to "div"
 })
 ```
-
-### Milestone
-
-- [ ] custom container in container
 
 [remarkjs]: https://github.com/remarkjs/remark
 [536]: https://github.com/remarkjs/remark/pull/536

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -5,13 +5,14 @@ import gfm from "remark-gfm";
 import remark2rehype from "remark-rehype";
 import stringify from "rehype-stringify";
 
-import container, { REGEX_CUSTOM_CONTAINER } from "..";
+import container, { REGEX_BEGIN } from "..";
 
 const compiler: Processor = remark()
   .use(gfm)
   .use(container, { className: "remark-container" })
-  .use(remark2rehype)
-  .use(stringify);
+  // to check if it handles HTML in markdown
+  .use(remark2rehype, { allowDangerousHtml: true })
+  .use(stringify, { allowDangerousHtml: true });
 
 const process = async (contents: VFileCompatible): Promise<VFileCompatible> => {
   return compiler.process(contents).then((file) => file.value);
@@ -19,45 +20,128 @@ const process = async (contents: VFileCompatible): Promise<VFileCompatible> => {
 
 describe("remark-container", () => {
   it("REGEX_CUSTOM_CONTAINER matches with custom container", () => {
-    const input = "::: warn\ncontainer body\n:::";
-    const match = input.match(REGEX_CUSTOM_CONTAINER);
+    const input = "::: warn";
+    const match = input.match(REGEX_BEGIN);
     expect(match).not.toBeNull();
 
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    const [_input, type, title, content] = match!;
+    const [_input, type, title] = match!;
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     expect(type).toBe("warn");
-    expect(title).toBe("");
-    expect(content).toBe("container body");
+    expect(title).toBeUndefined();
   });
 
-  it("REGEX_CUSTOM_CONTAINER matches with custom container with custom title", () => {
-    const input =
-      "::: warn custom title\ncontainer body\nsecond line body\n:::";
-    const match = input.match(REGEX_CUSTOM_CONTAINER);
+  it("REGEX_CUSTOM_CONTAINER matches with custom container", () => {
+    const input = `:::
+      warn`;
+    const match = input.match(REGEX_BEGIN);
     expect(match).not.toBeNull();
 
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    const [_input, type, title, content] = match!;
+    const [_input, type, title] = match!;
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+    expect(type).toBe("warn");
+    expect(title).toBeUndefined();
+  });
+
+  it("REGEX_CUSTOM_CONTAINER matches with custom container with custom title", () => {
+    const input = "::: warn custom title";
+    const match = input.match(REGEX_BEGIN);
+    expect(match).not.toBeNull();
+
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    const [_input, type, title] = match!;
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     expect(type).toBe("warn");
     expect(title).toBe("custom title");
-    expect(content).toBe("container body\nsecond line body");
+  });
+
+  it("works with empty", async () => {
+    const input = `
+  :::warn
+
+  :::`;
+
+    const expected = '<div class="remark-container warn"></div>';
+    expect(await process(input)).toBe(expected);
   });
 
   it("interprets custom container directives", async () => {
-    const input = "::: warn\ncontainer body\n:::";
-    const expected =
-      '<p><div class="remark-container warn">container body</div></p>';
+    const input = `
+:::warn
+
+container body
+
+:::
+  `;
+    const expected = `<div class="remark-container warn"><p>container body</p></div>`;
     expect(await process(input)).toBe(expected);
   });
 
-  it("interprets custom title after container directives", async () => {
-    const input = "::: info custom title\ncontainer body\n:::";
-    const expected =
-      '<p><div class="remark-container info"><div class="remark-container__title">custom title</div>container body</div></p>';
+  it("interprets multiple custom container", async () => {
+    const input = `
+normal body
+
+::: info first
+
+first container body
+
+:::
+
+normal body
+
+normal body
+
+::: warn second
+
+second container body
+
+:::
+
+normal body
+
+rest element`;
+
+    const expected = `<p>normal body</p>
+<div class="remark-container info"><div class="remark-container__title">first</div><p>first container body</p></div>
+<p>normal body</p>
+<p>normal body</p>
+<div class="remark-container warn"><div class="remark-container__title">second</div><p>second container body</p></div>
+<p>normal body</p>
+<p>rest element</p>`;
+
     expect(await process(input)).toBe(expected);
   });
+
+  // it("interprets children contains html", async () => {
+  //   const input = `
+  // ::: info
+
+  // Lorem<br />ipsum.
+
+  // ::hr{.red}
+
+  // sample
+  // <div>foo</div>
+
+  // A :i[lovely] language know as :abbr[HTML]{title="HyperText Markup Language"}.
+
+  // \`undefined\` is inline code block.
+
+  // :::
+  // `;
+  //   const expected = `
+  // <div class="remark-container info">
+  // <p>Lorem<br />ipsum.</p>
+  // <p>::hr{.red}</p>
+  // <p>sample</p>
+  // <div>foo</div>
+  // <p>A :i[lovely] language know as :abbr[HTML]{title="HyperText Markup Language"}.</p>
+  // <p><code>undefined</code> is inline code block.</p>
+  // </div>`.replace(/\n/g, "");
+  //   expect(await process(input)).toBe(expected);
+  // });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -116,32 +116,32 @@ rest element`;
     expect(await process(input)).toBe(expected);
   });
 
-  // it("interprets children contains html", async () => {
-  //   const input = `
-  // ::: info
+  it("interprets children contains html", async () => {
+    const input = `
+::: info
 
-  // Lorem<br />ipsum.
+Lorem<br />ipsum.
 
-  // ::hr{.red}
+::hr{.red}
 
-  // sample
-  // <div>foo</div>
+sample
+<div>foo</div>
 
-  // A :i[lovely] language know as :abbr[HTML]{title="HyperText Markup Language"}.
+A :i[lovely] language know as :abbr[HTML]{title="HyperText Markup Language"}.
 
-  // \`undefined\` is inline code block.
+\`undefined\` is inline code block.
 
-  // :::
-  // `;
-  //   const expected = `
-  // <div class="remark-container info">
-  // <p>Lorem<br />ipsum.</p>
-  // <p>::hr{.red}</p>
-  // <p>sample</p>
-  // <div>foo</div>
-  // <p>A :i[lovely] language know as :abbr[HTML]{title="HyperText Markup Language"}.</p>
-  // <p><code>undefined</code> is inline code block.</p>
-  // </div>`.replace(/\n/g, "");
-  //   expect(await process(input)).toBe(expected);
-  // });
+:::
+  `;
+    const expected = `
+<div class="remark-container info">
+<p>Lorem<br />ipsum.</p>
+<p>::hr{.red}</p>
+<p>sample</p>
+<div>foo</div>
+<p>A :i[lovely] language know as :abbr[HTML]{title="HyperText Markup Language"}.</p>
+<p><code>undefined</code> is inline code block.</p>
+</div>`.replace(/\n/g, "");
+    expect(await process(input)).toBe(expected);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,11 @@ import { visit } from "unist-util-visit";
 
 import type { Plugin, Transformer } from "unified";
 import type { Node, Literal, Parent } from "unist";
+import type { Paragraph } from "mdast";
+import { Data } from "vfile";
 
-export const REGEX_CUSTOM_CONTAINER =
-  /^\s*:::\s*(\w+)\s*(.*?)[\n\r]([\s\S]+?)\s*:::\s*?/;
+export const REGEX_BEGIN = /^\s*:::\s*(\w+)\s*(.*)?/;
+export const REGEX_END = /^\s*:::$/;
 
 interface CustomContainerOptions {
   /**
@@ -26,54 +28,116 @@ const isLiteralNode = (node: Node): node is Literal => {
   return "value" in node;
 };
 
+const isParagraph = (node: Node): node is Paragraph => {
+  return "paragraph" === node.type;
+};
+
+// TODO
+// const isCustomDirective = (node: Node): Literal | undefined => {
+//   if (!isParagraph(node)) return;
+//   const elem = node.children[0];
+
+//   if (
+//     isLiteralNode(elem) &&
+//     !!(elem.value.match(REGEX_BEGIN) || elem.value.match(REGEX_END))
+//   ) {
+//     return elem;
+//   }
+// };
+
 export const plugin: Plugin<[CustomContainerOptions?]> = (
   options?: CustomContainerOptions
 ): Transformer => {
   const settings = Object.assign({}, DEFAULT_SETTINGS, options);
 
+  // Constructs `Parent` node of custom directive which contains given children.
+  const constructContainer = (
+    children: Node<Data>[],
+    className: string
+  ): Parent => {
+    return {
+      type: "container",
+      children,
+      data: {
+        hName: settings.containerTag,
+        hProperties: {
+          className: [settings.className, className.toLowerCase()],
+        },
+      },
+    };
+  };
+
+  const constructTitle = (title: string): Paragraph => {
+    return {
+      type: "paragraph",
+      children: [{ type: "text", value: title }],
+      data: {
+        hName: "div",
+        hProperties: { className: [`${settings.className}__title`] },
+      },
+    };
+  };
+
   const transformer: Transformer = (tree: Node): void => {
-    visit(tree, (node: Node, index: number | null, parent?: Parent): void => {
-      if (index == null) return;
+    visit(tree, (_node: Node, _index: number | null, parent?: Parent): void => {
       if (!parent) return;
-      if (!isLiteralNode(node)) return;
-      if (typeof node.value !== "string" || node.type !== "text") return;
 
-      const match = node.value.match(REGEX_CUSTOM_CONTAINER);
-      if (!match) return;
+      const children: Node<Data>[] = [];
+      const len = parent.children.length;
+      // we walk through each children in `parent` to look for custom directive.
+      let currentIndex = -1;
+      while (currentIndex < len - 1) {
+        currentIndex += 1;
+        // check if currentIndex of children contains begin node of custom directive
+        const currentNode = parent.children[currentIndex];
+        children.push(currentNode);
+        if (!isParagraph(currentNode)) continue;
+        // XXX: Consider checking other children in currentNode
+        const currentElem = currentNode.children[0];
+        if (!isLiteralNode(currentElem)) continue;
 
-      // NOTE title may be null
-      const [_input, type, title, content] = match;
+        const match = currentElem.value.match(REGEX_BEGIN);
+        if (!match) continue;
+        // Here we're inside of the custom directive. let's find nearest closing directive.
+        // remove last element, which is custom directive marker.
+        children.pop();
+        const beginIndex = currentIndex;
+        let innerIndex = currentIndex - 1;
+        while (innerIndex < len - 1) {
+          innerIndex += 1;
+          const currentNode = parent.children[innerIndex];
+          if (!isParagraph(currentNode)) continue;
+          const currentElem = currentNode.children[0];
+          if (
+            !isLiteralNode(currentElem) ||
+            !currentElem.value.match(REGEX_END)
+          )
+            continue;
+          // here we found the closing directive.
+          const [_input, type, title] = match;
+          // remove surrounding `:::` markers and treat rest of them as children of the container
+          const containerChildren = parent.children.slice(
+            beginIndex + 1,
+            innerIndex
+          );
+          if (title?.length > 0) {
+            containerChildren.splice(0, 0, constructTitle(title));
+          }
 
-      const children = [];
+          const container = constructContainer(
+            containerChildren,
+            type.toLowerCase()
+          );
 
-      if (title.length > 0) {
-        children.push({
-          type: "container",
-          children: [{ type: "text", value: title }],
-          data: {
-            hName: "div",
-            hProperties: { className: [`${settings.className}__title`] },
-          },
-        });
+          children.push(container);
+          currentIndex = innerIndex - 1;
+          break;
+        }
+
+        currentIndex += 1;
       }
 
-      children.push({
-        type: "text",
-        value: content,
-      });
-
-      const container: Parent = {
-        type: "container",
-        children,
-        data: {
-          hName: settings.containerTag,
-          hProperties: {
-            className: [settings.className, type.toLowerCase()],
-          },
-        },
-      };
-
-      parent.children[index] = container;
+      parent.children = children;
     });
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,19 +32,6 @@ const isParagraph = (node: Node): node is Paragraph => {
   return "paragraph" === node.type;
 };
 
-// TODO
-// const isCustomDirective = (node: Node): Literal | undefined => {
-//   if (!isParagraph(node)) return;
-//   const elem = node.children[0];
-
-//   if (
-//     isLiteralNode(elem) &&
-//     !!(elem.value.match(REGEX_BEGIN) || elem.value.match(REGEX_END))
-//   ) {
-//     return elem;
-//   }
-// };
-
 export const plugin: Plugin<[CustomContainerOptions?]> = (
   options?: CustomContainerOptions
 ): Transformer => {


### PR DESCRIPTION
Resolves https://github.com/koka831/remark-custom-container/issues/120
This PR allows custom container to have multiple elements inside it.

### example

![image](https://user-images.githubusercontent.com/14945055/203831631-c49c36e0-925b-4554-8ac5-1057c8d681cf.png)


### TODO

- [ ] Update README
  - add breaking change (maybe CHANGELOG.md)
  - update example
- [ ] consider refactoring