### PR TITLE
added conditional exports by setting package entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,16 @@
   "author": "koka831",
   "license": "MIT",
   "type": "module",
-  "export": "dist/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git@github.com:koka831/remark-custom-container.git"


### PR DESCRIPTION
When I import `remark-custom-container` in another project, it works fine, but when I test the project with `jest`, the `jest resolver` is not able to find the `remark-custom-container` in `node_modules`.

**This PR fixes the import issue raised by `jest resolver`.**

For the reference: [package entry points](https://nodejs.org/api/packages.html#package-entry-points)
Additional reference: [in typescriptlang.org](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing)